### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ The ``poke-jenkins`` is a Mercurial extension that for the heads of an incoming 
 
 .. image:: https://api.travis-ci.org/paylogic/poke-jenkins.png
    :target: https://travis-ci.org/paylogic/poke-jenkins
-.. image:: https://pypip.in/v/poke-jenkins/badge.png
+.. image:: https://img.shields.io/pypi/v/poke-jenkins.svg
    :target: https://crate.io/packages/poke-jenkins/
 .. image:: https://coveralls.io/repos/paylogic/poke-jenkins/badge.png?branch=master
    :target: https://coveralls.io/r/paylogic/poke-jenkins


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20poke-jenkins))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `poke-jenkins`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.